### PR TITLE
Add support for extra AWS Batch environment variables.

### DIFF
--- a/metaflow/plugins/metadata/__init__.py
+++ b/metaflow/plugins/metadata/__init__.py
@@ -1,2 +1,3 @@
+from .az_auth import AZAuth
 from .local import LocalMetadataProvider
 from .service import ServiceMetadataProvider

--- a/metaflow/plugins/metadata/az_auth.py
+++ b/metaflow/plugins/metadata/az_auth.py
@@ -1,8 +1,6 @@
 import atexit
 import os
 
-from az_app_login.util import build_fetcher, get_access_token, load_cache, save_cache
-
 AUTH_PROFILE_ENV_VAR = "METAFLOW_AUTH_PROFILE"
 OBO_TOKEN_ENV_VAR = "METAFLOW_OBO_TOKEN"
 
@@ -24,6 +22,8 @@ class AZAuth:
     @property
     def cache(self):
         if not self._cache:
+            from az_app_login.util import load_cache, save_cache
+
             self._cache = load_cache()
             atexit.register(save_cache, self._cache)
         return self._cache
@@ -31,6 +31,8 @@ class AZAuth:
     @property
     def fetcher(self):
         if self.profile and not self._fetcher:
+            from az_app_login.util import build_fetcher
+
             self._fetcher = build_fetcher(
                 cache=self.cache, profile=self.profile, obo_token=self.obo_token
             )
@@ -46,5 +48,6 @@ class AZAuth:
     def get_access_token(self):
         if not self.fetcher:
             return None
-        return get_access_token(self.fetcher)
+        from az_app_login.util import get_access_token
 
+        return get_access_token(self.fetcher)["access_token"]

--- a/metaflow/plugins/metadata/az_auth.py
+++ b/metaflow/plugins/metadata/az_auth.py
@@ -1,0 +1,50 @@
+import atexit
+import os
+
+from az_app_login.util import build_fetcher, get_access_token, load_cache, save_cache
+
+AUTH_PROFILE_ENV_VAR = "METAFLOW_AUTH_PROFILE"
+OBO_TOKEN_ENV_VAR = "METAFLOW_OBO_TOKEN"
+
+
+class AZAuth:
+    _fetcher = None
+    _cache = None
+
+    def __init__(
+        self,
+        profile=os.environ.get(AUTH_PROFILE_ENV_VAR),
+        obo_token=os.environ.get(OBO_TOKEN_ENV_VAR),
+        cache=None,
+    ):
+        self.profile = profile
+        self.obo_token = obo_token
+        self._cache = cache
+
+    @property
+    def cache(self):
+        if not self._cache:
+            self._cache = load_cache()
+            atexit.register(save_cache, self._cache)
+        return self._cache
+
+    @property
+    def fetcher(self):
+        if self.profile and not self._fetcher:
+            self._fetcher = build_fetcher(
+                cache=self.cache, profile=self.profile, obo_token=self.obo_token
+            )
+        return self._fetcher
+
+    def __call__(self, r):
+        token = self.get_access_token()
+        if not token:
+            return r
+        r.headers["Authorization"] = f"Bearer {token}"
+        return r
+
+    def get_access_token(self):
+        if not self.fetcher:
+            return None
+        return get_access_token(self.fetcher)
+

--- a/metaflow/plugins/metadata/service.py
+++ b/metaflow/plugins/metadata/service.py
@@ -25,10 +25,12 @@ def default_request_args():
 
 
 def http_get(uri, **kwargs):
+    """ Adds default arguments requests.get """
     return requests.get(uri, **{**default_request_args(), **kwargs})
 
 
 def http_post(uri, **kwargs):
+    """ Adds default arguments requests.post """
     return requests.post(uri, **{**default_request_args(), **kwargs})
 
 

--- a/metaflow/plugins/metadata/service.py
+++ b/metaflow/plugins/metadata/service.py
@@ -52,10 +52,6 @@ class ServiceMetadataProvider(MetadataProvider):
     def default_info(cls):
         return METADATA_SERVICE_URL
 
-    @classmethod
-    def default_request_args(cls):
-        return METADATA_SERVICE_URL
-
 
     def version(self):
         return self._version(self._monitor)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(name='metaflow',
         'click>=7.0',
         'requests',
         'boto3',
-        'pylint<2.5.0'
+        'pylint<2.5.0',
+        'az-app-login>=0.3.0'
       ],
       tests_require = [
         'coverage'


### PR DESCRIPTION
They can be specified with the "METAFLOW_AWS_BATCH_EXTRA_ENV"
environment variable, which must be a json list of objects with
"name" and either "value" or "tokenProfile" keys.
In the latter case the value is set to the access token
fetched with the specified profile.